### PR TITLE
Bug/#266: TeamCheckPage indexOf 버그 해결하기

### DIFF
--- a/screens/components/TeamCheckPage.js
+++ b/screens/components/TeamCheckPage.js
@@ -103,6 +103,7 @@ export default TeamCheckPage = (props) => {
         ),
         newChecklist
       );
+
       if (!isSubmitedByEnter) {
         const updatedIsWritingNewTask = { ...isWritingNewTask };
         updatedIsWritingNewTask[memberName] = false;
@@ -112,6 +113,7 @@ export default TeamCheckPage = (props) => {
     } else {
       setIsWritingNewTask((prev) => ({ ...prev, [memberName]: false }));
     }
+    await getCheckLists();
   };
 
   const handleCheckboxChange = async (writer, id, newValue) => {
@@ -174,7 +176,6 @@ export default TeamCheckPage = (props) => {
       })
     );
 
-    // console.log("[TeamCheckPage]:asdf ", checkList);
     setChecklists(checkList);
   };
 


### PR DESCRIPTION
문제:
addNewTask시 getCheckList를 하지 않아서, firebase에서 생성된 아이디를 불러오지 못함 -> 즉 체크하는 함수 실행 시, id 값이 없기 때문에 에러가 발생함.

해결:
addNewTask 끝자락에 getCheckList함수를 추가