### PR TITLE
refactor/#371: 개인 화면에서 팀 타스크 삭제할때 팀 화면 까지 삭제 할 수 있게 

### DIFF
--- a/screens/components/CategoryItem.js
+++ b/screens/components/CategoryItem.js
@@ -327,7 +327,20 @@ export default CategoryItem = ({getCheckMap, ...props}) => {
           "teamCheckList",
           selectedChecklist.id,
         );
+
+        const teamRef = doc(
+          db,
+          "team",
+          selectedChecklist.teamCode,
+          "assignmentList",
+          selectedChecklist.assignmentId,
+          "memberEmail",
+          user.email,
+          "checkList",
+          selectedChecklist.id,
+        )
         await deleteDoc(teamtaskRef);
+        await deleteDoc(teamRef);
       }
     } catch (error) {
       console.error("Error deleting document: ", error);


### PR DESCRIPTION
If you delete a team task in PersonalPage, delete the same task in TeamPage as well